### PR TITLE
LUGG-927 Correct HTML when displaying Authors field

### DIFF
--- a/luggage_aliases.module
+++ b/luggage_aliases.module
@@ -120,7 +120,7 @@ function luggage_aliases_field_formatter_view($entity_type, $entity, $field, $in
             '#lastname' => $user->field_people_last_name[LANGUAGE_NONE][0]['value'],
             '#position' => $user->field_people_position[LANGUAGE_NONE][0]['value'],
             '#url' => $user->nid,
-            '#bio' => (isset($user->field_people_bio[LANGUAGE_NONE][0]['value']))?substr($user->field_people_bio[LANGUAGE_NONE][0]['value'],0,300) . '...':'',
+            '#bio' => (isset($user->field_people_bio[LANGUAGE_NONE][0]['value']))?filter_dom_serialize(filter_dom_load(substr($user->field_people_bio[LANGUAGE_NONE][0]['value'],0,300) . '...')):'',
           );
         } else {
           $term = taxonomy_term_load($item['tid']);

--- a/luggage_aliases.module
+++ b/luggage_aliases.module
@@ -120,7 +120,7 @@ function luggage_aliases_field_formatter_view($entity_type, $entity, $field, $in
             '#lastname' => $user->field_people_last_name[LANGUAGE_NONE][0]['value'],
             '#position' => $user->field_people_position[LANGUAGE_NONE][0]['value'],
             '#url' => $user->nid,
-            '#bio' => (isset($user->field_people_bio[LANGUAGE_NONE][0]['value']))?filter_dom_serialize(filter_dom_load(substr($user->field_people_bio[LANGUAGE_NONE][0]['value'],0,300) . '...')):'',
+            '#bio' => (isset($user->field_people_bio[LANGUAGE_NONE][0]['value'])) ? filter_dom_serialize(filter_dom_load(substr($user->field_people_bio[LANGUAGE_NONE][0]['value'],0,300) . '...')) : '',
           );
         } else {
           $term = taxonomy_term_load($item['tid']);


### PR DESCRIPTION
Taking form what Drupal Does for the HTML corrector filter, I wrapped the output in filter_dom_serialize(filter_dom_load()). https://api.drupal.org/api/drupal/modules%21filter%21filter.module/function/_filter_htmlcorrector/7.x

_filter_htmlcorrector() is a 'private' function (denoted by it starting with and underscore) so I just replicated what it does and seems to do the trick in my testing.