### PR TITLE
EEOB-56 Gave circle avatars a width

### DIFF
--- a/css/luggage_aliases.css
+++ b/css/luggage_aliases.css
@@ -14,6 +14,7 @@
 
 .img-avatar {
     height: 56px;
+    width: 56px;
     vertical-align: middle;
 }
 


### PR DESCRIPTION
Without a width set anywhere, responsive image css from height: auto
!Important was making these blow up.